### PR TITLE
docs: mark neuriplo-kserve-runtime gRPC as live-validated

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ ctest --output-on-failure -R docker_run_inference_e2e_owlv2_dry_run
 ## ⚠️ Known Limitations
 - Windows builds not currently supported
 - Some model/backend combinations may require specific export configurations
-- KServe HTTP mode is validated live against `neuriplo-kserve-runtime`; gRPC support is built only when Protobuf/gRPC are available. Triton/OVMS round-trips run as a CI dry-run on every PR, with live runs behind a manual dispatch — see [docs/KserveCompatibility.md](docs/KserveCompatibility.md). FP16/BF16 inputs over gRPC require raw tensor contents (the default; the typed-`contents` fallback selected by `KSERVE_BINARY=0` cannot carry them).
+- KServe HTTP and gRPC are validated live against `neuriplo-kserve-runtime` (gRPC requires Protobuf/gRPC at build time). Triton/OVMS round-trips run as a CI dry-run on every PR, with live runs behind a manual dispatch — see [docs/KserveCompatibility.md](docs/KserveCompatibility.md). FP16/BF16 inputs over gRPC require raw tensor contents (the default; the typed-`contents` fallback selected by `KSERVE_BINARY=0` cannot carry them).
 - KServe TLS is supported on both transports: HTTPS for the HTTP client (requires an OpenSSL-enabled build) and `grpcs://` for the gRPC client, with optional mTLS via `KSERVE_CLIENT_CERT`/`KSERVE_CLIENT_KEY`. A build without OpenSSL still works over plaintext `http://`, but `https://` endpoints fail fast with a clear error.
 - KServe model management (Model Repository extension: index / load / unload) is implemented on the client API for both transports but is not yet exposed through the CLI, and is only available when the server enables the extension (e.g. Triton `--model-control-mode=explicit`); see [docs/KserveRuntime.md](docs/KserveRuntime.md).
 

--- a/docs/KserveCompatibility.md
+++ b/docs/KserveCompatibility.md
@@ -28,7 +28,7 @@ Legend: ✅ exercised live in CI · 🟡 dry-run only (live behind manual dispat
 
 | Server | HTTP | gRPC | Notes |
 |--------|------|------|-------|
-| neuriplo-kserve-runtime | ✅ validated | 🟡 | reference target |
+| neuriplo-kserve-runtime | ✅ validated | ✅ validated | reference target; gRPC live-validated 2026-06-12 via client conformance + infer `KserveEngine` after runtime PR #9 (`raw_output_contents`) |
 | Triton Inference Server | 🟡 (live: dispatch) | 🟡 (live: dispatch) | ONNX backend; `grpcurl` over `proto/kserve_grpc.proto` |
 | OpenVINO Model Server (OVMS) | 🟡 (live: dispatch) | 🟡 (live: dispatch) | same OIP endpoints; serves ONNX directly |
 | TorchServe (OIP) | ⏳ | ⏳ | version routing varies |
@@ -90,6 +90,9 @@ bash app/test/kserve_integration.sh --live
 
 # Narrow it down:
 bash app/test/kserve_integration.sh --live --servers triton --transports http
+
+# Live client <-> neuriplo-kserve-runtime (sibling repo; HTTP + gRPC):
+# ../neuriplo-kserve-client/scripts/runtime_conformance.sh --live
 ```
 
 See [docs/KserveRuntime.md](KserveRuntime.md) for the full KServe runtime


### PR DESCRIPTION
## Summary
- Update `docs/KserveCompatibility.md`: neuriplo-kserve-runtime gRPC column 🟡 → ✅ validated (2026-06-12, after runtime PR #9 `raw_output_contents`).
- Align `README.md` limitations bullet: HTTP and gRPC both validated against runtime.
- Add runtime conformance script pointer under "Running it yourself".

## Test plan
- [x] Docs reflect live validation already run (`runtime_conformance.sh --live`, infer `KserveEngine` gRPC e2e)
- [ ] Human merge (docs-only; CI skipped via paths-ignore)


Made with [Cursor](https://cursor.com)