### PR TITLE
fix(ci): publish-release Latest check uses unsupported gh JSON field

### DIFF
--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -91,5 +91,11 @@ jobs:
         run: |
           tag="${{ steps.meta.outputs.tag }}"
           gh release edit "${tag}" --latest --title "${tag}"
-          gh release view "${tag}" --json tagName,isLatest,url \
-            --jq '"\(.tagName) isLatest=\(.isLatest) \(.url)"'
+          # 'isLatest' is not a valid --json field for gh release view on the
+          # runners; verify through the REST API instead.
+          latest="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)"
+          if [ "${latest}" != "${tag}" ]; then
+            echo "::error::expected ${tag} to be Latest, but GitHub reports ${latest}" >&2
+            exit 1
+          fi
+          echo "${tag} is marked Latest"


### PR DESCRIPTION
Fixes the red `Publish GitHub Release` runs ([v0.6.1](https://github.com/olibartfast/neuriplo-infer/actions/runs/27427342955), v0.6.0 same): the verification line uses `gh release view --json isLatest`, which the runner's gh (2.45) rejects — the step has never passed since it was added for v0.5.0. The release itself publishes fine and `gh release edit --latest` succeeds; only the check is broken. Replaced with a real assertion via `GET /releases/latest`.

CI-only change, targets master because `workflow_run` workflows execute from the default branch. v0.6.1 is confirmed marked Latest already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)