### PR TITLE
fix: restore the local-only build and the model-type doc sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ separate explicit extension registry rather than growing the internal table
 indefinitely.
 
 <!-- TASKFACTORY_MODEL_LIST:START -->
-The TaskFactory supports the following model type strings. Matching normalizes strings by lowercasing and stripping whitespace, hyphens, and underscores, so `YOLO-V8`, `yolo_v8`, and ` yolo v8 ` route identically. Specific segmentation and pose aliases are checked before generic detection aliases.
+The TaskFactory supports the following model type strings. Matching normalizes strings by lowercasing and stripping whitespace, hyphens, and underscores, so `YOLO-V8`, `yolo_v8`, and ` yolo v8 ` route identically. Specific segmentation, pose, and depth aliases are checked before generic detection aliases.
 
 **Object Detection:**
 
@@ -162,6 +162,8 @@ For EdgeCrafter detection export details, see [export/detection/edgecrafter/READ
 - `"rfdetrseg"` - RF-DETR
 
 For EdgeCrafter segmentation export details, see [export/segmentation/edgecrafter/README.md](https://github.com/olibartfast/neuriplo-tasks/blob/master/export/segmentation/edgecrafter/README.md).
+
+Instance-segmentation tasks return masks by default. Set `TaskConfig::segmentation_output` to `SegmentationOutput::Polygon` to return full-image exterior rings and holes instead; see [instance-segmentation output representations](docs/segmentation_outputs.md).
 
 **Classification:**
 - `"torchvision-classifier"` - Torchvision models (ResNet, EfficientNet, etc.)
@@ -194,6 +196,8 @@ RF-DETR keypoint models output per-keypoint visibility and 2×2 pixel covariance
 **Depth Estimation:**
 - `"depth_anything_v2"`, `"depth-anything-v2"` - Depth Anything V2
 - `"yolo-depth"`, `"yolo26n-depth"` - Ultralytics YOLO26 depth models; any YOLO-prefixed model type containing `depth` routes here
+
+YOLO26 depth expects RGB NCHW float input normalized to `[0,1]` with YOLO letterboxing. Its exported output is an unbounded metric-depth map shaped `[B,1,H,W]`; postprocessing removes letterbox padding and resizes the map to the original frame. See the [YOLO depth export guide](https://github.com/olibartfast/neuriplo-tasks/blob/master/export/depth_estimation/yolo_depth/README.md).
 
 **Open-Vocabulary Detection:**
 - `"owlv2"` - OWLv2 open-vocabulary detection

--- a/app/test/test_KserveEnvelope.cpp
+++ b/app/test/test_KserveEnvelope.cpp
@@ -1,3 +1,7 @@
+// Both headers include KserveTypes.hpp from neuriplo-kserve-client, which is
+// not fetched in a local-only build. Guarded like test_KserveEngine.cpp.
+#ifdef NEURIPLO_INFER_WITH_KSERVE
+
 #include "EncodedImage.hpp"
 #include "KserveEnvelope.hpp"
 
@@ -270,3 +274,5 @@ TEST(EncodedImage, ReadsJpegDimensionsFromStartOfFrame) {
   EXPECT_EQ(width, 640);
   EXPECT_EQ(height, 480);
 }
+
+#endif // NEURIPLO_INFER_WITH_KSERVE

--- a/docs/generated/supported-model-types.md
+++ b/docs/generated/supported-model-types.md
@@ -13,7 +13,7 @@ separate explicit extension registry rather than growing the internal table
 indefinitely.
 
 <!-- TASKFACTORY_MODEL_LIST:START -->
-The TaskFactory supports the following model type strings. Matching normalizes strings by lowercasing and stripping whitespace, hyphens, and underscores, so `YOLO-V8`, `yolo_v8`, and ` yolo v8 ` route identically. Specific segmentation and pose aliases are checked before generic detection aliases.
+The TaskFactory supports the following model type strings. Matching normalizes strings by lowercasing and stripping whitespace, hyphens, and underscores, so `YOLO-V8`, `yolo_v8`, and ` yolo v8 ` route identically. Specific segmentation, pose, and depth aliases are checked before generic detection aliases.
 
 **Object Detection:**
 
@@ -35,6 +35,8 @@ For EdgeCrafter detection export details, see [export/detection/edgecrafter/READ
 - `"rfdetrseg"` - RF-DETR
 
 For EdgeCrafter segmentation export details, see [export/segmentation/edgecrafter/README.md](https://github.com/olibartfast/neuriplo-tasks/blob/master/export/segmentation/edgecrafter/README.md).
+
+Instance-segmentation tasks return masks by default. Set `TaskConfig::segmentation_output` to `SegmentationOutput::Polygon` to return full-image exterior rings and holes instead; see [instance-segmentation output representations](docs/segmentation_outputs.md).
 
 **Classification:**
 - `"torchvision-classifier"` - Torchvision models (ResNet, EfficientNet, etc.)
@@ -66,6 +68,9 @@ RF-DETR keypoint models output per-keypoint visibility and 2×2 pixel covariance
 
 **Depth Estimation:**
 - `"depth_anything_v2"`, `"depth-anything-v2"` - Depth Anything V2
+- `"yolo-depth"`, `"yolo26n-depth"` - Ultralytics YOLO26 depth models; any YOLO-prefixed model type containing `depth` routes here
+
+YOLO26 depth expects RGB NCHW float input normalized to `[0,1]` with YOLO letterboxing. Its exported output is an unbounded metric-depth map shaped `[B,1,H,W]`; postprocessing removes letterbox padding and resizes the map to the original frame. See the [YOLO depth export guide](https://github.com/olibartfast/neuriplo-tasks/blob/master/export/depth_estimation/yolo_depth/README.md).
 
 **Open-Vocabulary Detection:**
 - `"owlv2"` - OWLv2 open-vocabulary detection


### PR DESCRIPTION
Two independent CI breaks on `develop` ([run 30962871350](https://github.com/olibartfast/neuriplo-infer/actions/runs/30962871350)).

**KServe (local-only) — build failure.** `test_KserveEnvelope.cpp` had no `NEURIPLO_INFER_WITH_KSERVE` guard, unlike its sibling `test_KserveEngine.cpp`. Both `EncodedImage.hpp` and `KserveEnvelope.hpp` include `KserveTypes.hpp` from neuriplo-kserve-client, which a local-only build never fetches, so the translation unit failed with `fatal error: KserveTypes.hpp: No such file or directory`. Guarded the same way as its sibling.

**Build & Test (OPENCV_DNN) — `Check model-type docs are in sync`.** The generated docs were stale against the neuriplo-tasks v0.8.0 README this repo now pins: missing the YOLO26 depth entries, the depth export note and the polygon segmentation note, and the alias-precedence sentence still read "segmentation and pose" without depth. Regenerated with `scripts/sync_supported_model_types.py`, so `--check` passes.

Verified locally by reproducing the local-only configuration exactly as CI runs it (`NEURIPLO_INFER_ENABLE_KSERVE=OFF`, `ENABLE_GRPC=OFF`, `ENABLE_LOCAL_BACKENDS=ON`): builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GzPTWY4a5PJxPo8pqVAWV